### PR TITLE
Ignore meta characters in substring

### DIFF
--- a/BOString/BOStringMaker.m
+++ b/BOString/BOStringMaker.m
@@ -153,7 +153,7 @@ typedef NS_ENUM(NSInteger, BOStringMakerStringCommand) {
             case BOStringMakerEachStringCommand:
             {
                 NSRegularExpression *expression = [NSRegularExpression regularExpressionWithPattern:string
-                                                                                            options:0
+                                                                                            options:NSRegularExpressionIgnoreMetacharacters
                                                                                               error:nil];
                 
                 NSRange range = NSMakeRange(0, [_attributedString length]);

--- a/Examples/BOStringDemo.xcodeproj/project.pbxproj
+++ b/Examples/BOStringDemo.xcodeproj/project.pbxproj
@@ -1,2367 +1,1063 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>archiveVersion</key>
-	<string>1</string>
-	<key>classes</key>
-	<dict/>
-	<key>objectVersion</key>
-	<string>46</string>
-	<key>objects</key>
-	<dict>
-		<key>04F3C5F794C047F88B8FF9A1</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Copy Pods Resources</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/../Pods/Target Support Files/Pods-BOStringTests_iOS/Pods-BOStringTests_iOS-resources.sh"
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>06C18B2BB157AD87538B41AE</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Embed Pods Frameworks</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/../Pods/Target Support Files/Pods-BOStringDemo_iOS/Pods-BOStringDemo_iOS-frameworks.sh"
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>201DF0E5185A098100062FB4</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>201DF0F7185A098100062FB4</string>
-				<string>201DF11D185A0B7500062FB4</string>
-				<string>201DF0FE185A098100062FB4</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>201DF0E6185A098100062FB4</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>201DF0EB185A098100062FB4</string>
-				<string>D765F5DE624F413A8AF4272E</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>201DF0E7185A098100062FB4</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>201DF0F5185A098100062FB4</string>
-				<string>201DF103185A098100062FB4</string>
-				<string>201DF101185A098100062FB4</string>
-			</array>
-			<key>isa</key>
-			<string>PBXResourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>201DF0E8185A098100062FB4</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>201DF119185A098100062FB4</string>
-			<key>buildPhases</key>
-			<array>
-				<string>7FFB9E59766A4D309BA7D244</string>
-				<string>201DF0E5185A098100062FB4</string>
-				<string>201DF0E6185A098100062FB4</string>
-				<string>201DF0E7185A098100062FB4</string>
-				<string>8BF32328C0884358A9EF8406</string>
-				<string>457AC0CF5AE93D603F6A484A</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>BOStringDemo_OSX</string>
-			<key>productName</key>
-			<string>BOStringDemo_OSX</string>
-			<key>productReference</key>
-			<string>201DF0E9185A098100062FB4</string>
-			<key>productType</key>
-			<string>com.apple.product-type.application</string>
-		</dict>
-		<key>201DF0E9185A098100062FB4</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.application</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>BOStringDemo_OSX.app</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>201DF0EA185A098100062FB4</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Cocoa.framework</string>
-			<key>path</key>
-			<string>Library/Frameworks/Cocoa.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>201DF0EB185A098100062FB4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>201DF0EA185A098100062FB4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>201DF0EC185A098100062FB4</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>201DF0ED185A098100062FB4</string>
-				<string>201DF0EE185A098100062FB4</string>
-				<string>201DF0EF185A098100062FB4</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Other Frameworks</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>201DF0ED185A098100062FB4</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>AppKit.framework</string>
-			<key>path</key>
-			<string>Library/Frameworks/AppKit.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>201DF0EE185A098100062FB4</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CoreData.framework</string>
-			<key>path</key>
-			<string>Library/Frameworks/CoreData.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>201DF0EF185A098100062FB4</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Foundation.framework</string>
-			<key>path</key>
-			<string>Library/Frameworks/Foundation.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>201DF0F0185A098100062FB4</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>201DF11B185A0B7500062FB4</string>
-				<string>201DF11C185A0B7500062FB4</string>
-				<string>201DF0FC185A098100062FB4</string>
-				<string>201DF0FD185A098100062FB4</string>
-				<string>201DF0FF185A098100062FB4</string>
-				<string>201DF102185A098100062FB4</string>
-				<string>201DF0F1185A098100062FB4</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>BOStringDemo_OSX</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>201DF0F1185A098100062FB4</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>201DF0F2185A098100062FB4</string>
-				<string>201DF0F3185A098100062FB4</string>
-				<string>201DF0F6185A098100062FB4</string>
-				<string>201DF0F8185A098100062FB4</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Supporting Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>201DF0F2185A098100062FB4</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>BOStringDemo_OSX-Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>201DF0F3185A098100062FB4</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>201DF0F4185A098100062FB4</string>
-			</array>
-			<key>isa</key>
-			<string>PBXVariantGroup</string>
-			<key>name</key>
-			<string>InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>201DF0F4185A098100062FB4</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.strings</string>
-			<key>name</key>
-			<string>en</string>
-			<key>path</key>
-			<string>en.lproj/InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>201DF0F5185A098100062FB4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>201DF0F3185A098100062FB4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>201DF0F6185A098100062FB4</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>main.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>201DF0F7185A098100062FB4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>201DF0F6185A098100062FB4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>201DF0F8185A098100062FB4</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>BOStringDemo_OSX-Prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>201DF0FC185A098100062FB4</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>BOSAppDelegate.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>201DF0FD185A098100062FB4</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>BOSAppDelegate.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>201DF0FE185A098100062FB4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>201DF0FD185A098100062FB4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>201DF0FF185A098100062FB4</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>201DF100185A098100062FB4</string>
-			</array>
-			<key>isa</key>
-			<string>PBXVariantGroup</string>
-			<key>name</key>
-			<string>MainMenu.xib</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>201DF100185A098100062FB4</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>file.xib</string>
-			<key>name</key>
-			<string>Base</string>
-			<key>path</key>
-			<string>Base.lproj/MainMenu.xib</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>201DF101185A098100062FB4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>201DF0FF185A098100062FB4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>201DF102185A098100062FB4</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>folder.assetcatalog</string>
-			<key>path</key>
-			<string>Images.xcassets</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>201DF103185A098100062FB4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>201DF102185A098100062FB4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>201DF104185A098100062FB4</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>201DF11E185A0D7E00062FB4</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>201DF105185A098100062FB4</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>201DF10A185A098100062FB4</string>
-				<string>201DF109185A098100062FB4</string>
-				<string>50A2A449111A45E4AD4544B0</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>201DF106185A098100062FB4</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>201DF112185A098100062FB4</string>
-			</array>
-			<key>isa</key>
-			<string>PBXResourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>201DF107185A098100062FB4</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>201DF11A185A098100062FB4</string>
-			<key>buildPhases</key>
-			<array>
-				<string>8726B34B673D4547B20125C5</string>
-				<string>201DF104185A098100062FB4</string>
-				<string>201DF105185A098100062FB4</string>
-				<string>201DF106185A098100062FB4</string>
-				<string>E4A859871EA14B9CB73876B7</string>
-				<string>4678D0BC13BD838119493404</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>201DF10C185A098100062FB4</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>BOStringTests_OSX</string>
-			<key>productName</key>
-			<string>BOStringDemo_OSXTests</string>
-			<key>productReference</key>
-			<string>201DF108185A098100062FB4</string>
-			<key>productType</key>
-			<string>com.apple.product-type.bundle.unit-test</string>
-		</dict>
-		<key>201DF108185A098100062FB4</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.cfbundle</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>BOStringTests_OSX.xctest</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>201DF109185A098100062FB4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>20F462F4185607A300A92906</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>201DF10A185A098100062FB4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>201DF0EA185A098100062FB4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>201DF10B185A098100062FB4</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>2051B71E184799DA00D6DA45</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>201DF0E8185A098100062FB4</string>
-			<key>remoteInfo</key>
-			<string>BOStringDemo_OSX</string>
-		</dict>
-		<key>201DF10C185A098100062FB4</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>target</key>
-			<string>201DF0E8185A098100062FB4</string>
-			<key>targetProxy</key>
-			<string>201DF10B185A098100062FB4</string>
-		</dict>
-		<key>201DF10D185A098100062FB4</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>201DF10E185A098100062FB4</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>BOStringDemo_OSXTests</string>
-			<key>path</key>
-			<string>../BOStringDemo_OSXTests</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>201DF10E185A098100062FB4</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>201DF10F185A098100062FB4</string>
-				<string>201DF110185A098100062FB4</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Supporting Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>201DF10F185A098100062FB4</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>BOStringDemo_OSXTests-Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>201DF110185A098100062FB4</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>201DF111185A098100062FB4</string>
-			</array>
-			<key>isa</key>
-			<string>PBXVariantGroup</string>
-			<key>name</key>
-			<string>InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>201DF111185A098100062FB4</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.strings</string>
-			<key>name</key>
-			<string>en</string>
-			<key>path</key>
-			<string>en.lproj/InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>201DF112185A098100062FB4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>201DF110185A098100062FB4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>201DF115185A098100062FB4</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>D7D3CC2CDC1AEFA43C1B71CB</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ASSETCATALOG_COMPILER_APPICON_NAME</key>
-				<string>AppIcon</string>
-				<key>COMBINE_HIDPI_IMAGES</key>
-				<string>YES</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-				</array>
-				<key>GCC_ENABLE_OBJC_EXCEPTIONS</key>
-				<string>YES</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>BOStringDemo_OSX/BOStringDemo_OSX-Prefix.pch</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>INFOPLIST_FILE</key>
-				<string>BOStringDemo_OSX/BOStringDemo_OSX-Info.plist</string>
-				<key>MACOSX_DEPLOYMENT_TARGET</key>
-				<string>10.9</string>
-				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
-				<string>ru.kovpas.${PRODUCT_NAME:rfc1034identifier}</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>macosx</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>app</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>201DF116185A098100062FB4</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>7C63CA07892AECA7AA65D714</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ASSETCATALOG_COMPILER_APPICON_NAME</key>
-				<string>AppIcon</string>
-				<key>COMBINE_HIDPI_IMAGES</key>
-				<string>YES</string>
-				<key>DEBUG_INFORMATION_FORMAT</key>
-				<string>dwarf-with-dsym</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-				</array>
-				<key>GCC_ENABLE_OBJC_EXCEPTIONS</key>
-				<string>YES</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>BOStringDemo_OSX/BOStringDemo_OSX-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>BOStringDemo_OSX/BOStringDemo_OSX-Info.plist</string>
-				<key>MACOSX_DEPLOYMENT_TARGET</key>
-				<string>10.9</string>
-				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
-				<string>ru.kovpas.${PRODUCT_NAME:rfc1034identifier}</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>macosx</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>app</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>201DF117185A098100062FB4</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>764245D088FCC0326DEB9CA4</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>BUNDLE_LOADER</key>
-				<string>$(BUILT_PRODUCTS_DIR)/BOStringDemo_OSX.app/Contents/MacOS/BOStringDemo_OSX</string>
-				<key>COMBINE_HIDPI_IMAGES</key>
-				<string>YES</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_ENABLE_OBJC_EXCEPTIONS</key>
-				<string>YES</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>BOStringDemo_OSX/BOStringDemo_OSX-Prefix.pch</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>INFOPLIST_FILE</key>
-				<string>BOStringDemo_OSXTests/BOStringDemo_OSXTests-Info.plist</string>
-				<key>MACOSX_DEPLOYMENT_TARGET</key>
-				<string>10.9</string>
-				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
-				<string>ru.kovpas.${PRODUCT_NAME:rfc1034identifier}</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>macosx</string>
-				<key>TEST_HOST</key>
-				<string>$(BUNDLE_LOADER)</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>xctest</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>201DF118185A098100062FB4</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>C1F7A7DD840597E94163C297</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>BUNDLE_LOADER</key>
-				<string>$(BUILT_PRODUCTS_DIR)/BOStringDemo_OSX.app/Contents/MacOS/BOStringDemo_OSX</string>
-				<key>COMBINE_HIDPI_IMAGES</key>
-				<string>YES</string>
-				<key>DEBUG_INFORMATION_FORMAT</key>
-				<string>dwarf-with-dsym</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_ENABLE_OBJC_EXCEPTIONS</key>
-				<string>YES</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>BOStringDemo_OSX/BOStringDemo_OSX-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>BOStringDemo_OSXTests/BOStringDemo_OSXTests-Info.plist</string>
-				<key>MACOSX_DEPLOYMENT_TARGET</key>
-				<string>10.9</string>
-				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
-				<string>ru.kovpas.${PRODUCT_NAME:rfc1034identifier}</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>macosx</string>
-				<key>TEST_HOST</key>
-				<string>$(BUNDLE_LOADER)</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>xctest</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>201DF119185A098100062FB4</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>201DF115185A098100062FB4</string>
-				<string>201DF116185A098100062FB4</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>201DF11A185A098100062FB4</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>201DF117185A098100062FB4</string>
-				<string>201DF118185A098100062FB4</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>201DF11B185A0B7500062FB4</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>BOStringDemoViewController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>201DF11C185A0B7500062FB4</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>BOStringDemoViewController.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>201DF11D185A0B7500062FB4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>201DF11C185A0B7500062FB4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>201DF11E185A0D7E00062FB4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>20F46306185607C600A92906</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>201DF11F185A0D9C00062FB4</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>20F462F9185607A300A92906</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>BOStringDemo_iOSTests</string>
-			<key>path</key>
-			<string>..</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>201DF122185A195000062FB4</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>201DF0F0185A098100062FB4</string>
-				<string>2051B72F184799DA00D6DA45</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Demo</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2051B71D184799DA00D6DA45</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>201DF122185A195000062FB4</string>
-				<string>20F462F8185607A300A92906</string>
-				<string>2051B728184799DA00D6DA45</string>
-				<string>2051B727184799DA00D6DA45</string>
-				<string>5528B1CA8AC590139C4E4770</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2051B71E184799DA00D6DA45</key>
-		<dict>
-			<key>attributes</key>
-			<dict>
-				<key>CLASSPREFIX</key>
-				<string>BOS</string>
-				<key>LastUpgradeCheck</key>
-				<string>0720</string>
-				<key>ORGANIZATIONNAME</key>
-				<string>Home</string>
-				<key>TargetAttributes</key>
-				<dict>
-					<key>201DF107185A098100062FB4</key>
-					<dict>
-						<key>TestTargetID</key>
-						<string>201DF0E8185A098100062FB4</string>
-					</dict>
-					<key>20F462F2185607A300A92906</key>
-					<dict>
-						<key>TestTargetID</key>
-						<string>2051B725184799DA00D6DA45</string>
-					</dict>
-				</dict>
-			</dict>
-			<key>buildConfigurationList</key>
-			<string>2051B721184799DA00D6DA45</string>
-			<key>compatibilityVersion</key>
-			<string>Xcode 3.2</string>
-			<key>developmentRegion</key>
-			<string>English</string>
-			<key>hasScannedForEncodings</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXProject</string>
-			<key>knownRegions</key>
-			<array>
-				<string>en</string>
-				<string>Base</string>
-			</array>
-			<key>mainGroup</key>
-			<string>2051B71D184799DA00D6DA45</string>
-			<key>productRefGroup</key>
-			<string>2051B727184799DA00D6DA45</string>
-			<key>projectDirPath</key>
-			<string></string>
-			<key>projectReferences</key>
-			<array/>
-			<key>projectRoot</key>
-			<string></string>
-			<key>targets</key>
-			<array>
-				<string>2051B725184799DA00D6DA45</string>
-				<string>20F462F2185607A300A92906</string>
-				<string>201DF0E8185A098100062FB4</string>
-				<string>201DF107185A098100062FB4</string>
-			</array>
-		</dict>
-		<key>2051B721184799DA00D6DA45</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>2051B750184799DA00D6DA45</string>
-				<string>2051B751184799DA00D6DA45</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>2051B722184799DA00D6DA45</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>2051B736184799DA00D6DA45</string>
-				<string>206F59A8184CBA8600EC5F5F</string>
-				<string>2051B73A184799DA00D6DA45</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>2051B723184799DA00D6DA45</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>2051B72C184799DA00D6DA45</string>
-				<string>2051B72E184799DA00D6DA45</string>
-				<string>2051B72A184799DA00D6DA45</string>
-				<string>7744E3AE1DC94FD5B9BB8A99</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>2051B724184799DA00D6DA45</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>2051B734184799DA00D6DA45</string>
-				<string>2051B73C184799DA00D6DA45</string>
-			</array>
-			<key>isa</key>
-			<string>PBXResourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>2051B725184799DA00D6DA45</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>2051B752184799DA00D6DA45</string>
-			<key>buildPhases</key>
-			<array>
-				<string>D55E3E0EA7BC4478B2787676</string>
-				<string>2051B722184799DA00D6DA45</string>
-				<string>2051B723184799DA00D6DA45</string>
-				<string>2051B724184799DA00D6DA45</string>
-				<string>E14B0B82DD5747A880D3E8E5</string>
-				<string>06C18B2BB157AD87538B41AE</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>BOStringDemo_iOS</string>
-			<key>productName</key>
-			<string>BOStringDemo</string>
-			<key>productReference</key>
-			<string>2051B726184799DA00D6DA45</string>
-			<key>productType</key>
-			<string>com.apple.product-type.application</string>
-		</dict>
-		<key>2051B726184799DA00D6DA45</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.application</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>BOStringDemo_iOS.app</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>2051B727184799DA00D6DA45</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>2051B726184799DA00D6DA45</string>
-				<string>20F462F3185607A300A92906</string>
-				<string>201DF0E9185A098100062FB4</string>
-				<string>201DF108185A098100062FB4</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Products</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2051B728184799DA00D6DA45</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>2051B729184799DA00D6DA45</string>
-				<string>2051B72B184799DA00D6DA45</string>
-				<string>2051B72D184799DA00D6DA45</string>
-				<string>20F462F4185607A300A92906</string>
-				<string>201DF0EA185A098100062FB4</string>
-				<string>201DF0EC185A098100062FB4</string>
-				<string>735C978B88CE494D81B600A4</string>
-				<string>4A2B5AA6D5AE4600B69EE238</string>
-				<string>4CD5ED3A192F4428913CE1EE</string>
-				<string>21E1686CB7AC47C19AF95BB9</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Frameworks</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2051B729184799DA00D6DA45</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Foundation.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/Foundation.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>2051B72A184799DA00D6DA45</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2051B729184799DA00D6DA45</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2051B72B184799DA00D6DA45</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CoreGraphics.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/CoreGraphics.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>2051B72C184799DA00D6DA45</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2051B72B184799DA00D6DA45</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2051B72D184799DA00D6DA45</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>UIKit.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/UIKit.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>2051B72E184799DA00D6DA45</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2051B72D184799DA00D6DA45</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2051B72F184799DA00D6DA45</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>2051B738184799DA00D6DA45</string>
-				<string>2051B739184799DA00D6DA45</string>
-				<string>206F59A6184CBA8600EC5F5F</string>
-				<string>206F59A7184CBA8600EC5F5F</string>
-				<string>2051B73B184799DA00D6DA45</string>
-				<string>2051B730184799DA00D6DA45</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>BOStringDemo_iOS</string>
-			<key>path</key>
-			<string>BOStringDemo</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2051B730184799DA00D6DA45</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>2051B731184799DA00D6DA45</string>
-				<string>2051B732184799DA00D6DA45</string>
-				<string>2051B735184799DA00D6DA45</string>
-				<string>2051B737184799DA00D6DA45</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Supporting Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2051B731184799DA00D6DA45</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>BOStringDemo-Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2051B732184799DA00D6DA45</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>2051B733184799DA00D6DA45</string>
-			</array>
-			<key>isa</key>
-			<string>PBXVariantGroup</string>
-			<key>name</key>
-			<string>InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2051B733184799DA00D6DA45</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.strings</string>
-			<key>name</key>
-			<string>en</string>
-			<key>path</key>
-			<string>en.lproj/InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2051B734184799DA00D6DA45</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2051B732184799DA00D6DA45</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2051B735184799DA00D6DA45</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>main.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2051B736184799DA00D6DA45</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2051B735184799DA00D6DA45</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2051B737184799DA00D6DA45</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>BOStringDemo-Prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2051B738184799DA00D6DA45</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>BOSAppDelegate.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2051B739184799DA00D6DA45</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>BOSAppDelegate.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2051B73A184799DA00D6DA45</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2051B739184799DA00D6DA45</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2051B73B184799DA00D6DA45</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>folder.assetcatalog</string>
-			<key>path</key>
-			<string>Images.xcassets</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2051B73C184799DA00D6DA45</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2051B73B184799DA00D6DA45</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2051B750184799DA00D6DA45</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>ENABLE_TESTABILITY</key>
-				<string>YES</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>ONLY_ACTIVE_ARCH</key>
-				<string>YES</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>2051B751184799DA00D6DA45</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>ENABLE_NS_ASSERTIONS</key>
-				<string>NO</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>2051B752184799DA00D6DA45</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>2051B753184799DA00D6DA45</string>
-				<string>2051B754184799DA00D6DA45</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>2051B753184799DA00D6DA45</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>C4D3589F8C646E0F714807CC</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ASSETCATALOG_COMPILER_APPICON_NAME</key>
-				<string>AppIcon</string>
-				<key>ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME</key>
-				<string>LaunchImage</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>BOStringDemo/BOStringDemo-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>BOStringDemo/BOStringDemo-Info.plist</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>6.0</string>
-				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
-				<string>ru.kovpas.${PRODUCT_NAME:rfc1034identifier}</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>app</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>2051B754184799DA00D6DA45</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>BCBDA0AF5EC6CCD70B601D36</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ASSETCATALOG_COMPILER_APPICON_NAME</key>
-				<string>AppIcon</string>
-				<key>ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME</key>
-				<string>LaunchImage</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>BOStringDemo/BOStringDemo-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>BOStringDemo/BOStringDemo-Info.plist</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>6.0</string>
-				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
-				<string>ru.kovpas.${PRODUCT_NAME:rfc1034identifier}</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>app</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>206F59A6184CBA8600EC5F5F</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>BOStringDemoViewController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>206F59A7184CBA8600EC5F5F</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>BOStringDemoViewController.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>206F59A8184CBA8600EC5F5F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>206F59A7184CBA8600EC5F5F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>20F462EF185607A300A92906</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>20F46307185607C600A92906</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>20F462F0185607A300A92906</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>20F462F5185607A300A92906</string>
-				<string>20F462F7185607A300A92906</string>
-				<string>20F462F6185607A300A92906</string>
-				<string>3C9885A5700C435C9854911D</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>20F462F1185607A300A92906</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>20F462FD185607A300A92906</string>
-			</array>
-			<key>isa</key>
-			<string>PBXResourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>20F462F2185607A300A92906</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>20F46303185607A300A92906</string>
-			<key>buildPhases</key>
-			<array>
-				<string>607AF9ADBADF47F582211B6A</string>
-				<string>20F462EF185607A300A92906</string>
-				<string>20F462F0185607A300A92906</string>
-				<string>20F462F1185607A300A92906</string>
-				<string>04F3C5F794C047F88B8FF9A1</string>
-				<string>3BAF4CAFE0E444820CE8F6DC</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>20F46302185607A300A92906</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>BOStringTests_iOS</string>
-			<key>productName</key>
-			<string>BOStringTests</string>
-			<key>productReference</key>
-			<string>20F462F3185607A300A92906</string>
-			<key>productType</key>
-			<string>com.apple.product-type.bundle.unit-test</string>
-		</dict>
-		<key>20F462F3185607A300A92906</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.cfbundle</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>BOStringTests_iOS.xctest</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>20F462F4185607A300A92906</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>XCTest.framework</string>
-			<key>path</key>
-			<string>Library/Frameworks/XCTest.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>20F462F5185607A300A92906</key>
-		<dict>
-			<key>fileRef</key>
-			<string>20F462F4185607A300A92906</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>20F462F6185607A300A92906</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2051B729184799DA00D6DA45</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>20F462F7185607A300A92906</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2051B72D184799DA00D6DA45</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>20F462F8185607A300A92906</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>201DF10D185A098100062FB4</string>
-				<string>201DF11F185A0D9C00062FB4</string>
-				<string>20F46306185607C600A92906</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Tests</string>
-			<key>path</key>
-			<string>BOStringTests</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>20F462F9185607A300A92906</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>20F462FA185607A300A92906</string>
-				<string>20F462FB185607A300A92906</string>
-				<string>20F46300185607A300A92906</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Supporting Files</string>
-			<key>path</key>
-			<string>BOStringTests</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>20F462FA185607A300A92906</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>BOStringTests-Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>20F462FB185607A300A92906</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>20F462FC185607A300A92906</string>
-			</array>
-			<key>isa</key>
-			<string>PBXVariantGroup</string>
-			<key>name</key>
-			<string>InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>20F462FC185607A300A92906</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.strings</string>
-			<key>name</key>
-			<string>en</string>
-			<key>path</key>
-			<string>en.lproj/InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>20F462FD185607A300A92906</key>
-		<dict>
-			<key>fileRef</key>
-			<string>20F462FB185607A300A92906</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>20F46300185607A300A92906</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>BOStringTests-Prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>20F46301185607A300A92906</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>2051B71E184799DA00D6DA45</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>2051B725184799DA00D6DA45</string>
-			<key>remoteInfo</key>
-			<string>BOStringDemo</string>
-		</dict>
-		<key>20F46302185607A300A92906</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>target</key>
-			<string>2051B725184799DA00D6DA45</string>
-			<key>targetProxy</key>
-			<string>20F46301185607A300A92906</string>
-		</dict>
-		<key>20F46303185607A300A92906</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>20F46304185607A300A92906</string>
-				<string>20F46305185607A300A92906</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>20F46304185607A300A92906</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>364B2B2C5DC159EBF2E68F31</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>BUNDLE_LOADER</key>
-				<string>$(BUILT_PRODUCTS_DIR)/BOStringDemo_iOS.app/BOStringDemo_iOS</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(SDKROOT)/Developer/Library/Frameworks</string>
-					<string>$(inherited)</string>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-				</array>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>BOStringTests/BOStringTests-Prefix.pch</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>INFOPLIST_FILE</key>
-				<string>BOStringTests/BOStringTests-Info.plist</string>
-				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
-				<string>ru.kovpas.${PRODUCT_NAME:rfc1034identifier}</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>TEST_HOST</key>
-				<string>$(BUNDLE_LOADER)</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>xctest</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>20F46305185607A300A92906</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>6DA05E2799A21BBC0644D01D</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>BUNDLE_LOADER</key>
-				<string>$(BUILT_PRODUCTS_DIR)/BOStringDemo_iOS.app/BOStringDemo_iOS</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(SDKROOT)/Developer/Library/Frameworks</string>
-					<string>$(inherited)</string>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-				</array>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>BOStringTests/BOStringTests-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>BOStringTests/BOStringTests-Info.plist</string>
-				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
-				<string>ru.kovpas.${PRODUCT_NAME:rfc1034identifier}</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>TEST_HOST</key>
-				<string>$(BUNDLE_LOADER)</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>xctest</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>20F46306185607C600A92906</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>BOStringTests.m</string>
-			<key>path</key>
-			<string>../../Tests/BOStringTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>20F46307185607C600A92906</key>
-		<dict>
-			<key>fileRef</key>
-			<string>20F46306185607C600A92906</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>21E1686CB7AC47C19AF95BB9</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-BOStringTests_iOS.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>364B2B2C5DC159EBF2E68F31</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-BOStringTests_iOS.debug.xcconfig</string>
-			<key>path</key>
-			<string>../Pods/Target Support Files/Pods-BOStringTests_iOS/Pods-BOStringTests_iOS.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3BAF4CAFE0E444820CE8F6DC</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Embed Pods Frameworks</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/../Pods/Target Support Files/Pods-BOStringTests_iOS/Pods-BOStringTests_iOS-frameworks.sh"
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>3C9885A5700C435C9854911D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>21E1686CB7AC47C19AF95BB9</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>457AC0CF5AE93D603F6A484A</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Embed Pods Frameworks</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/../Pods/Target Support Files/Pods-BOStringDemo_OSX/Pods-BOStringDemo_OSX-frameworks.sh"
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>4678D0BC13BD838119493404</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Embed Pods Frameworks</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/../Pods/Target Support Files/Pods-BOStringTests_OSX/Pods-BOStringTests_OSX-frameworks.sh"
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>4A2B5AA6D5AE4600B69EE238</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-BOStringDemo_iOS.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>4CD5ED3A192F4428913CE1EE</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-BOStringTests_OSX.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>50A2A449111A45E4AD4544B0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4CD5ED3A192F4428913CE1EE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>5528B1CA8AC590139C4E4770</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>D7D3CC2CDC1AEFA43C1B71CB</string>
-				<string>7C63CA07892AECA7AA65D714</string>
-				<string>C4D3589F8C646E0F714807CC</string>
-				<string>BCBDA0AF5EC6CCD70B601D36</string>
-				<string>764245D088FCC0326DEB9CA4</string>
-				<string>C1F7A7DD840597E94163C297</string>
-				<string>364B2B2C5DC159EBF2E68F31</string>
-				<string>6DA05E2799A21BBC0644D01D</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>607AF9ADBADF47F582211B6A</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Check Pods Manifest.lock</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
-if [[ $? != 0 ]] ; then
-    cat &lt;&lt; EOM
-error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
-EOM
-    exit 1
-fi
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>6DA05E2799A21BBC0644D01D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-BOStringTests_iOS.release.xcconfig</string>
-			<key>path</key>
-			<string>../Pods/Target Support Files/Pods-BOStringTests_iOS/Pods-BOStringTests_iOS.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>735C978B88CE494D81B600A4</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-BOStringDemo_OSX.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>764245D088FCC0326DEB9CA4</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-BOStringTests_OSX.debug.xcconfig</string>
-			<key>path</key>
-			<string>../Pods/Target Support Files/Pods-BOStringTests_OSX/Pods-BOStringTests_OSX.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7744E3AE1DC94FD5B9BB8A99</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4A2B5AA6D5AE4600B69EE238</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>7C63CA07892AECA7AA65D714</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-BOStringDemo_OSX.release.xcconfig</string>
-			<key>path</key>
-			<string>../Pods/Target Support Files/Pods-BOStringDemo_OSX/Pods-BOStringDemo_OSX.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7FFB9E59766A4D309BA7D244</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Check Pods Manifest.lock</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
-if [[ $? != 0 ]] ; then
-    cat &lt;&lt; EOM
-error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
-EOM
-    exit 1
-fi
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>8726B34B673D4547B20125C5</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Check Pods Manifest.lock</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
-if [[ $? != 0 ]] ; then
-    cat &lt;&lt; EOM
-error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
-EOM
-    exit 1
-fi
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>8BF32328C0884358A9EF8406</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Copy Pods Resources</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/../Pods/Target Support Files/Pods-BOStringDemo_OSX/Pods-BOStringDemo_OSX-resources.sh"
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>BCBDA0AF5EC6CCD70B601D36</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-BOStringDemo_iOS.release.xcconfig</string>
-			<key>path</key>
-			<string>../Pods/Target Support Files/Pods-BOStringDemo_iOS/Pods-BOStringDemo_iOS.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C1F7A7DD840597E94163C297</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-BOStringTests_OSX.release.xcconfig</string>
-			<key>path</key>
-			<string>../Pods/Target Support Files/Pods-BOStringTests_OSX/Pods-BOStringTests_OSX.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C4D3589F8C646E0F714807CC</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-BOStringDemo_iOS.debug.xcconfig</string>
-			<key>path</key>
-			<string>../Pods/Target Support Files/Pods-BOStringDemo_iOS/Pods-BOStringDemo_iOS.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D55E3E0EA7BC4478B2787676</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Check Pods Manifest.lock</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
-if [[ $? != 0 ]] ; then
-    cat &lt;&lt; EOM
-error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
-EOM
-    exit 1
-fi
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>D765F5DE624F413A8AF4272E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>735C978B88CE494D81B600A4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D7D3CC2CDC1AEFA43C1B71CB</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-BOStringDemo_OSX.debug.xcconfig</string>
-			<key>path</key>
-			<string>../Pods/Target Support Files/Pods-BOStringDemo_OSX/Pods-BOStringDemo_OSX.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E14B0B82DD5747A880D3E8E5</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Copy Pods Resources</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/../Pods/Target Support Files/Pods-BOStringDemo_iOS/Pods-BOStringDemo_iOS-resources.sh"
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>E4A859871EA14B9CB73876B7</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Copy Pods Resources</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/../Pods/Target Support Files/Pods-BOStringTests_OSX/Pods-BOStringTests_OSX-resources.sh"
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-	</dict>
-	<key>rootObject</key>
-	<string>2051B71E184799DA00D6DA45</string>
-</dict>
-</plist>
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		201DF0EB185A098100062FB4 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 201DF0EA185A098100062FB4 /* Cocoa.framework */; };
+		201DF0F5185A098100062FB4 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 201DF0F3185A098100062FB4 /* InfoPlist.strings */; };
+		201DF0F7185A098100062FB4 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 201DF0F6185A098100062FB4 /* main.m */; };
+		201DF0FE185A098100062FB4 /* BOSAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 201DF0FD185A098100062FB4 /* BOSAppDelegate.m */; };
+		201DF101185A098100062FB4 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 201DF0FF185A098100062FB4 /* MainMenu.xib */; };
+		201DF103185A098100062FB4 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 201DF102185A098100062FB4 /* Images.xcassets */; };
+		201DF109185A098100062FB4 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20F462F4185607A300A92906 /* XCTest.framework */; };
+		201DF10A185A098100062FB4 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 201DF0EA185A098100062FB4 /* Cocoa.framework */; };
+		201DF112185A098100062FB4 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 201DF110185A098100062FB4 /* InfoPlist.strings */; };
+		201DF11D185A0B7500062FB4 /* BOStringDemoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 201DF11C185A0B7500062FB4 /* BOStringDemoViewController.m */; };
+		201DF11E185A0D7E00062FB4 /* BOStringTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 20F46306185607C600A92906 /* BOStringTests.m */; };
+		2051B72A184799DA00D6DA45 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2051B729184799DA00D6DA45 /* Foundation.framework */; };
+		2051B72C184799DA00D6DA45 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2051B72B184799DA00D6DA45 /* CoreGraphics.framework */; };
+		2051B72E184799DA00D6DA45 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2051B72D184799DA00D6DA45 /* UIKit.framework */; };
+		2051B734184799DA00D6DA45 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 2051B732184799DA00D6DA45 /* InfoPlist.strings */; };
+		2051B736184799DA00D6DA45 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 2051B735184799DA00D6DA45 /* main.m */; };
+		2051B73A184799DA00D6DA45 /* BOSAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 2051B739184799DA00D6DA45 /* BOSAppDelegate.m */; };
+		2051B73C184799DA00D6DA45 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2051B73B184799DA00D6DA45 /* Images.xcassets */; };
+		206F59A8184CBA8600EC5F5F /* BOStringDemoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 206F59A7184CBA8600EC5F5F /* BOStringDemoViewController.m */; };
+		20F462F5185607A300A92906 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20F462F4185607A300A92906 /* XCTest.framework */; };
+		20F462F6185607A300A92906 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2051B729184799DA00D6DA45 /* Foundation.framework */; };
+		20F462F7185607A300A92906 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2051B72D184799DA00D6DA45 /* UIKit.framework */; };
+		20F462FD185607A300A92906 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 20F462FB185607A300A92906 /* InfoPlist.strings */; };
+		20F46307185607C600A92906 /* BOStringTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 20F46306185607C600A92906 /* BOStringTests.m */; };
+		3C9885A5700C435C9854911D /* libPods-BOStringTests_iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 21E1686CB7AC47C19AF95BB9 /* libPods-BOStringTests_iOS.a */; };
+		50A2A449111A45E4AD4544B0 /* libPods-BOStringTests_OSX.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4CD5ED3A192F4428913CE1EE /* libPods-BOStringTests_OSX.a */; };
+		7744E3AE1DC94FD5B9BB8A99 /* libPods-BOStringDemo_iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A2B5AA6D5AE4600B69EE238 /* libPods-BOStringDemo_iOS.a */; };
+		D765F5DE624F413A8AF4272E /* libPods-BOStringDemo_OSX.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 735C978B88CE494D81B600A4 /* libPods-BOStringDemo_OSX.a */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		201DF10B185A098100062FB4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2051B71E184799DA00D6DA45 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 201DF0E8185A098100062FB4;
+			remoteInfo = BOStringDemo_OSX;
+		};
+		20F46301185607A300A92906 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2051B71E184799DA00D6DA45 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2051B725184799DA00D6DA45;
+			remoteInfo = BOStringDemo;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		201DF0E9185A098100062FB4 /* BOStringDemo_OSX.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BOStringDemo_OSX.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		201DF0EA185A098100062FB4 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
+		201DF0ED185A098100062FB4 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
+		201DF0EE185A098100062FB4 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
+		201DF0EF185A098100062FB4 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		201DF0F2185A098100062FB4 /* BOStringDemo_OSX-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "BOStringDemo_OSX-Info.plist"; sourceTree = "<group>"; };
+		201DF0F4185A098100062FB4 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		201DF0F6185A098100062FB4 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		201DF0F8185A098100062FB4 /* BOStringDemo_OSX-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BOStringDemo_OSX-Prefix.pch"; sourceTree = "<group>"; };
+		201DF0FC185A098100062FB4 /* BOSAppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BOSAppDelegate.h; sourceTree = "<group>"; };
+		201DF0FD185A098100062FB4 /* BOSAppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BOSAppDelegate.m; sourceTree = "<group>"; };
+		201DF100185A098100062FB4 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
+		201DF102185A098100062FB4 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		201DF108185A098100062FB4 /* BOStringTests_OSX.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BOStringTests_OSX.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		201DF10F185A098100062FB4 /* BOStringDemo_OSXTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "BOStringDemo_OSXTests-Info.plist"; sourceTree = "<group>"; };
+		201DF111185A098100062FB4 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		201DF11B185A0B7500062FB4 /* BOStringDemoViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BOStringDemoViewController.h; sourceTree = "<group>"; };
+		201DF11C185A0B7500062FB4 /* BOStringDemoViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BOStringDemoViewController.m; sourceTree = "<group>"; };
+		2051B726184799DA00D6DA45 /* BOStringDemo_iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BOStringDemo_iOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		2051B729184799DA00D6DA45 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		2051B72B184799DA00D6DA45 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		2051B72D184799DA00D6DA45 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		2051B731184799DA00D6DA45 /* BOStringDemo-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "BOStringDemo-Info.plist"; sourceTree = "<group>"; };
+		2051B733184799DA00D6DA45 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		2051B735184799DA00D6DA45 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		2051B737184799DA00D6DA45 /* BOStringDemo-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BOStringDemo-Prefix.pch"; sourceTree = "<group>"; };
+		2051B738184799DA00D6DA45 /* BOSAppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BOSAppDelegate.h; sourceTree = "<group>"; };
+		2051B739184799DA00D6DA45 /* BOSAppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BOSAppDelegate.m; sourceTree = "<group>"; };
+		2051B73B184799DA00D6DA45 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		206F59A6184CBA8600EC5F5F /* BOStringDemoViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BOStringDemoViewController.h; sourceTree = "<group>"; };
+		206F59A7184CBA8600EC5F5F /* BOStringDemoViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BOStringDemoViewController.m; sourceTree = "<group>"; };
+		20F462F3185607A300A92906 /* BOStringTests_iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BOStringTests_iOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		20F462F4185607A300A92906 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		20F462FA185607A300A92906 /* BOStringTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "BOStringTests-Info.plist"; sourceTree = "<group>"; };
+		20F462FC185607A300A92906 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		20F46300185607A300A92906 /* BOStringTests-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BOStringTests-Prefix.pch"; sourceTree = "<group>"; };
+		20F46306185607C600A92906 /* BOStringTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BOStringTests.m; path = ../../Tests/BOStringTests.m; sourceTree = "<group>"; };
+		21E1686CB7AC47C19AF95BB9 /* libPods-BOStringTests_iOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BOStringTests_iOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		364B2B2C5DC159EBF2E68F31 /* Pods-BOStringTests_iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BOStringTests_iOS.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-BOStringTests_iOS/Pods-BOStringTests_iOS.debug.xcconfig"; sourceTree = "<group>"; };
+		4A2B5AA6D5AE4600B69EE238 /* libPods-BOStringDemo_iOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BOStringDemo_iOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		4CD5ED3A192F4428913CE1EE /* libPods-BOStringTests_OSX.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BOStringTests_OSX.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6DA05E2799A21BBC0644D01D /* Pods-BOStringTests_iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BOStringTests_iOS.release.xcconfig"; path = "../Pods/Target Support Files/Pods-BOStringTests_iOS/Pods-BOStringTests_iOS.release.xcconfig"; sourceTree = "<group>"; };
+		735C978B88CE494D81B600A4 /* libPods-BOStringDemo_OSX.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BOStringDemo_OSX.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		764245D088FCC0326DEB9CA4 /* Pods-BOStringTests_OSX.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BOStringTests_OSX.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-BOStringTests_OSX/Pods-BOStringTests_OSX.debug.xcconfig"; sourceTree = "<group>"; };
+		7C63CA07892AECA7AA65D714 /* Pods-BOStringDemo_OSX.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BOStringDemo_OSX.release.xcconfig"; path = "../Pods/Target Support Files/Pods-BOStringDemo_OSX/Pods-BOStringDemo_OSX.release.xcconfig"; sourceTree = "<group>"; };
+		BCBDA0AF5EC6CCD70B601D36 /* Pods-BOStringDemo_iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BOStringDemo_iOS.release.xcconfig"; path = "../Pods/Target Support Files/Pods-BOStringDemo_iOS/Pods-BOStringDemo_iOS.release.xcconfig"; sourceTree = "<group>"; };
+		C1F7A7DD840597E94163C297 /* Pods-BOStringTests_OSX.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BOStringTests_OSX.release.xcconfig"; path = "../Pods/Target Support Files/Pods-BOStringTests_OSX/Pods-BOStringTests_OSX.release.xcconfig"; sourceTree = "<group>"; };
+		C4D3589F8C646E0F714807CC /* Pods-BOStringDemo_iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BOStringDemo_iOS.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-BOStringDemo_iOS/Pods-BOStringDemo_iOS.debug.xcconfig"; sourceTree = "<group>"; };
+		D7D3CC2CDC1AEFA43C1B71CB /* Pods-BOStringDemo_OSX.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BOStringDemo_OSX.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-BOStringDemo_OSX/Pods-BOStringDemo_OSX.debug.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		201DF0E6185A098100062FB4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				201DF0EB185A098100062FB4 /* Cocoa.framework in Frameworks */,
+				D765F5DE624F413A8AF4272E /* libPods-BOStringDemo_OSX.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		201DF105185A098100062FB4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				201DF10A185A098100062FB4 /* Cocoa.framework in Frameworks */,
+				201DF109185A098100062FB4 /* XCTest.framework in Frameworks */,
+				50A2A449111A45E4AD4544B0 /* libPods-BOStringTests_OSX.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2051B723184799DA00D6DA45 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2051B72C184799DA00D6DA45 /* CoreGraphics.framework in Frameworks */,
+				2051B72E184799DA00D6DA45 /* UIKit.framework in Frameworks */,
+				2051B72A184799DA00D6DA45 /* Foundation.framework in Frameworks */,
+				7744E3AE1DC94FD5B9BB8A99 /* libPods-BOStringDemo_iOS.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		20F462F0185607A300A92906 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				20F462F5185607A300A92906 /* XCTest.framework in Frameworks */,
+				20F462F7185607A300A92906 /* UIKit.framework in Frameworks */,
+				20F462F6185607A300A92906 /* Foundation.framework in Frameworks */,
+				3C9885A5700C435C9854911D /* libPods-BOStringTests_iOS.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		201DF0EC185A098100062FB4 /* Other Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				201DF0ED185A098100062FB4 /* AppKit.framework */,
+				201DF0EE185A098100062FB4 /* CoreData.framework */,
+				201DF0EF185A098100062FB4 /* Foundation.framework */,
+			);
+			name = "Other Frameworks";
+			sourceTree = "<group>";
+		};
+		201DF0F0185A098100062FB4 /* BOStringDemo_OSX */ = {
+			isa = PBXGroup;
+			children = (
+				201DF11B185A0B7500062FB4 /* BOStringDemoViewController.h */,
+				201DF11C185A0B7500062FB4 /* BOStringDemoViewController.m */,
+				201DF0FC185A098100062FB4 /* BOSAppDelegate.h */,
+				201DF0FD185A098100062FB4 /* BOSAppDelegate.m */,
+				201DF0FF185A098100062FB4 /* MainMenu.xib */,
+				201DF102185A098100062FB4 /* Images.xcassets */,
+				201DF0F1185A098100062FB4 /* Supporting Files */,
+			);
+			path = BOStringDemo_OSX;
+			sourceTree = "<group>";
+		};
+		201DF0F1185A098100062FB4 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				201DF0F2185A098100062FB4 /* BOStringDemo_OSX-Info.plist */,
+				201DF0F3185A098100062FB4 /* InfoPlist.strings */,
+				201DF0F6185A098100062FB4 /* main.m */,
+				201DF0F8185A098100062FB4 /* BOStringDemo_OSX-Prefix.pch */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		201DF10D185A098100062FB4 /* BOStringDemo_OSXTests */ = {
+			isa = PBXGroup;
+			children = (
+				201DF10E185A098100062FB4 /* Supporting Files */,
+			);
+			name = BOStringDemo_OSXTests;
+			path = ../BOStringDemo_OSXTests;
+			sourceTree = "<group>";
+		};
+		201DF10E185A098100062FB4 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				201DF10F185A098100062FB4 /* BOStringDemo_OSXTests-Info.plist */,
+				201DF110185A098100062FB4 /* InfoPlist.strings */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		201DF11F185A0D9C00062FB4 /* BOStringDemo_iOSTests */ = {
+			isa = PBXGroup;
+			children = (
+				20F462F9185607A300A92906 /* Supporting Files */,
+			);
+			name = BOStringDemo_iOSTests;
+			path = ..;
+			sourceTree = "<group>";
+		};
+		201DF122185A195000062FB4 /* Demo */ = {
+			isa = PBXGroup;
+			children = (
+				201DF0F0185A098100062FB4 /* BOStringDemo_OSX */,
+				2051B72F184799DA00D6DA45 /* BOStringDemo_iOS */,
+			);
+			name = Demo;
+			sourceTree = "<group>";
+		};
+		2051B71D184799DA00D6DA45 = {
+			isa = PBXGroup;
+			children = (
+				201DF122185A195000062FB4 /* Demo */,
+				20F462F8185607A300A92906 /* Tests */,
+				2051B728184799DA00D6DA45 /* Frameworks */,
+				2051B727184799DA00D6DA45 /* Products */,
+				5528B1CA8AC590139C4E4770 /* Pods */,
+			);
+			sourceTree = "<group>";
+		};
+		2051B727184799DA00D6DA45 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				2051B726184799DA00D6DA45 /* BOStringDemo_iOS.app */,
+				20F462F3185607A300A92906 /* BOStringTests_iOS.xctest */,
+				201DF0E9185A098100062FB4 /* BOStringDemo_OSX.app */,
+				201DF108185A098100062FB4 /* BOStringTests_OSX.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		2051B728184799DA00D6DA45 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				2051B729184799DA00D6DA45 /* Foundation.framework */,
+				2051B72B184799DA00D6DA45 /* CoreGraphics.framework */,
+				2051B72D184799DA00D6DA45 /* UIKit.framework */,
+				20F462F4185607A300A92906 /* XCTest.framework */,
+				201DF0EA185A098100062FB4 /* Cocoa.framework */,
+				201DF0EC185A098100062FB4 /* Other Frameworks */,
+				735C978B88CE494D81B600A4 /* libPods-BOStringDemo_OSX.a */,
+				4A2B5AA6D5AE4600B69EE238 /* libPods-BOStringDemo_iOS.a */,
+				4CD5ED3A192F4428913CE1EE /* libPods-BOStringTests_OSX.a */,
+				21E1686CB7AC47C19AF95BB9 /* libPods-BOStringTests_iOS.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		2051B72F184799DA00D6DA45 /* BOStringDemo_iOS */ = {
+			isa = PBXGroup;
+			children = (
+				2051B738184799DA00D6DA45 /* BOSAppDelegate.h */,
+				2051B739184799DA00D6DA45 /* BOSAppDelegate.m */,
+				206F59A6184CBA8600EC5F5F /* BOStringDemoViewController.h */,
+				206F59A7184CBA8600EC5F5F /* BOStringDemoViewController.m */,
+				2051B73B184799DA00D6DA45 /* Images.xcassets */,
+				2051B730184799DA00D6DA45 /* Supporting Files */,
+			);
+			name = BOStringDemo_iOS;
+			path = BOStringDemo;
+			sourceTree = "<group>";
+		};
+		2051B730184799DA00D6DA45 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				2051B731184799DA00D6DA45 /* BOStringDemo-Info.plist */,
+				2051B732184799DA00D6DA45 /* InfoPlist.strings */,
+				2051B735184799DA00D6DA45 /* main.m */,
+				2051B737184799DA00D6DA45 /* BOStringDemo-Prefix.pch */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		20F462F8185607A300A92906 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				201DF10D185A098100062FB4 /* BOStringDemo_OSXTests */,
+				201DF11F185A0D9C00062FB4 /* BOStringDemo_iOSTests */,
+				20F46306185607C600A92906 /* BOStringTests.m */,
+			);
+			name = Tests;
+			path = BOStringTests;
+			sourceTree = "<group>";
+		};
+		20F462F9185607A300A92906 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				20F462FA185607A300A92906 /* BOStringTests-Info.plist */,
+				20F462FB185607A300A92906 /* InfoPlist.strings */,
+				20F46300185607A300A92906 /* BOStringTests-Prefix.pch */,
+			);
+			name = "Supporting Files";
+			path = BOStringTests;
+			sourceTree = "<group>";
+		};
+		5528B1CA8AC590139C4E4770 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				D7D3CC2CDC1AEFA43C1B71CB /* Pods-BOStringDemo_OSX.debug.xcconfig */,
+				7C63CA07892AECA7AA65D714 /* Pods-BOStringDemo_OSX.release.xcconfig */,
+				C4D3589F8C646E0F714807CC /* Pods-BOStringDemo_iOS.debug.xcconfig */,
+				BCBDA0AF5EC6CCD70B601D36 /* Pods-BOStringDemo_iOS.release.xcconfig */,
+				764245D088FCC0326DEB9CA4 /* Pods-BOStringTests_OSX.debug.xcconfig */,
+				C1F7A7DD840597E94163C297 /* Pods-BOStringTests_OSX.release.xcconfig */,
+				364B2B2C5DC159EBF2E68F31 /* Pods-BOStringTests_iOS.debug.xcconfig */,
+				6DA05E2799A21BBC0644D01D /* Pods-BOStringTests_iOS.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		201DF0E8185A098100062FB4 /* BOStringDemo_OSX */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 201DF119185A098100062FB4 /* Build configuration list for PBXNativeTarget "BOStringDemo_OSX" */;
+			buildPhases = (
+				7FFB9E59766A4D309BA7D244 /* 📦 Check Pods Manifest.lock */,
+				201DF0E5185A098100062FB4 /* Sources */,
+				201DF0E6185A098100062FB4 /* Frameworks */,
+				201DF0E7185A098100062FB4 /* Resources */,
+				8BF32328C0884358A9EF8406 /* 📦 Copy Pods Resources */,
+				457AC0CF5AE93D603F6A484A /* 📦 Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = BOStringDemo_OSX;
+			productName = BOStringDemo_OSX;
+			productReference = 201DF0E9185A098100062FB4 /* BOStringDemo_OSX.app */;
+			productType = "com.apple.product-type.application";
+		};
+		201DF107185A098100062FB4 /* BOStringTests_OSX */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 201DF11A185A098100062FB4 /* Build configuration list for PBXNativeTarget "BOStringTests_OSX" */;
+			buildPhases = (
+				8726B34B673D4547B20125C5 /* 📦 Check Pods Manifest.lock */,
+				201DF104185A098100062FB4 /* Sources */,
+				201DF105185A098100062FB4 /* Frameworks */,
+				201DF106185A098100062FB4 /* Resources */,
+				E4A859871EA14B9CB73876B7 /* 📦 Copy Pods Resources */,
+				4678D0BC13BD838119493404 /* 📦 Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				201DF10C185A098100062FB4 /* PBXTargetDependency */,
+			);
+			name = BOStringTests_OSX;
+			productName = BOStringDemo_OSXTests;
+			productReference = 201DF108185A098100062FB4 /* BOStringTests_OSX.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		2051B725184799DA00D6DA45 /* BOStringDemo_iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2051B752184799DA00D6DA45 /* Build configuration list for PBXNativeTarget "BOStringDemo_iOS" */;
+			buildPhases = (
+				D55E3E0EA7BC4478B2787676 /* 📦 Check Pods Manifest.lock */,
+				2051B722184799DA00D6DA45 /* Sources */,
+				2051B723184799DA00D6DA45 /* Frameworks */,
+				2051B724184799DA00D6DA45 /* Resources */,
+				E14B0B82DD5747A880D3E8E5 /* 📦 Copy Pods Resources */,
+				6CC18964A72AC56A9B129E8A /* 📦 Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = BOStringDemo_iOS;
+			productName = BOStringDemo;
+			productReference = 2051B726184799DA00D6DA45 /* BOStringDemo_iOS.app */;
+			productType = "com.apple.product-type.application";
+		};
+		20F462F2185607A300A92906 /* BOStringTests_iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 20F46303185607A300A92906 /* Build configuration list for PBXNativeTarget "BOStringTests_iOS" */;
+			buildPhases = (
+				607AF9ADBADF47F582211B6A /* 📦 Check Pods Manifest.lock */,
+				20F462EF185607A300A92906 /* Sources */,
+				20F462F0185607A300A92906 /* Frameworks */,
+				20F462F1185607A300A92906 /* Resources */,
+				04F3C5F794C047F88B8FF9A1 /* 📦 Copy Pods Resources */,
+				3BAF4CAFE0E444820CE8F6DC /* 📦 Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				20F46302185607A300A92906 /* PBXTargetDependency */,
+			);
+			name = BOStringTests_iOS;
+			productName = BOStringTests;
+			productReference = 20F462F3185607A300A92906 /* BOStringTests_iOS.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		2051B71E184799DA00D6DA45 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				CLASSPREFIX = BOS;
+				LastUpgradeCheck = 0720;
+				ORGANIZATIONNAME = Home;
+				TargetAttributes = {
+					201DF107185A098100062FB4 = {
+						TestTargetID = 201DF0E8185A098100062FB4;
+					};
+					20F462F2185607A300A92906 = {
+						TestTargetID = 2051B725184799DA00D6DA45;
+					};
+				};
+			};
+			buildConfigurationList = 2051B721184799DA00D6DA45 /* Build configuration list for PBXProject "BOStringDemo" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 2051B71D184799DA00D6DA45;
+			productRefGroup = 2051B727184799DA00D6DA45 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				2051B725184799DA00D6DA45 /* BOStringDemo_iOS */,
+				20F462F2185607A300A92906 /* BOStringTests_iOS */,
+				201DF0E8185A098100062FB4 /* BOStringDemo_OSX */,
+				201DF107185A098100062FB4 /* BOStringTests_OSX */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		201DF0E7185A098100062FB4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				201DF0F5185A098100062FB4 /* InfoPlist.strings in Resources */,
+				201DF103185A098100062FB4 /* Images.xcassets in Resources */,
+				201DF101185A098100062FB4 /* MainMenu.xib in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		201DF106185A098100062FB4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				201DF112185A098100062FB4 /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2051B724184799DA00D6DA45 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2051B734184799DA00D6DA45 /* InfoPlist.strings in Resources */,
+				2051B73C184799DA00D6DA45 /* Images.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		20F462F1185607A300A92906 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				20F462FD185607A300A92906 /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		04F3C5F794C047F88B8FF9A1 /* 📦 Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-BOStringTests_iOS/Pods-BOStringTests_iOS-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		3BAF4CAFE0E444820CE8F6DC /* 📦 Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-BOStringTests_iOS/Pods-BOStringTests_iOS-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		457AC0CF5AE93D603F6A484A /* 📦 Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-BOStringDemo_OSX/Pods-BOStringDemo_OSX-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		4678D0BC13BD838119493404 /* 📦 Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-BOStringTests_OSX/Pods-BOStringTests_OSX-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		607AF9ADBADF47F582211B6A /* 📦 Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		6CC18964A72AC56A9B129E8A /* 📦 Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-BOStringDemo_iOS/Pods-BOStringDemo_iOS-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		7FFB9E59766A4D309BA7D244 /* 📦 Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		8726B34B673D4547B20125C5 /* 📦 Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		8BF32328C0884358A9EF8406 /* 📦 Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-BOStringDemo_OSX/Pods-BOStringDemo_OSX-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		D55E3E0EA7BC4478B2787676 /* 📦 Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		E14B0B82DD5747A880D3E8E5 /* 📦 Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-BOStringDemo_iOS/Pods-BOStringDemo_iOS-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E4A859871EA14B9CB73876B7 /* 📦 Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-BOStringTests_OSX/Pods-BOStringTests_OSX-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		201DF0E5185A098100062FB4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				201DF0F7185A098100062FB4 /* main.m in Sources */,
+				201DF11D185A0B7500062FB4 /* BOStringDemoViewController.m in Sources */,
+				201DF0FE185A098100062FB4 /* BOSAppDelegate.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		201DF104185A098100062FB4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				201DF11E185A0D7E00062FB4 /* BOStringTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2051B722184799DA00D6DA45 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2051B736184799DA00D6DA45 /* main.m in Sources */,
+				206F59A8184CBA8600EC5F5F /* BOStringDemoViewController.m in Sources */,
+				2051B73A184799DA00D6DA45 /* BOSAppDelegate.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		20F462EF185607A300A92906 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				20F46307185607C600A92906 /* BOStringTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		201DF10C185A098100062FB4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 201DF0E8185A098100062FB4 /* BOStringDemo_OSX */;
+			targetProxy = 201DF10B185A098100062FB4 /* PBXContainerItemProxy */;
+		};
+		20F46302185607A300A92906 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2051B725184799DA00D6DA45 /* BOStringDemo_iOS */;
+			targetProxy = 20F46301185607A300A92906 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		201DF0F3185A098100062FB4 /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				201DF0F4185A098100062FB4 /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		201DF0FF185A098100062FB4 /* MainMenu.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				201DF100185A098100062FB4 /* Base */,
+			);
+			name = MainMenu.xib;
+			sourceTree = "<group>";
+		};
+		201DF110185A098100062FB4 /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				201DF111185A098100062FB4 /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		2051B732184799DA00D6DA45 /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				2051B733184799DA00D6DA45 /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		20F462FB185607A300A92906 /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				20F462FC185607A300A92906 /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		201DF115185A098100062FB4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D7D3CC2CDC1AEFA43C1B71CB /* Pods-BOStringDemo_OSX.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "BOStringDemo_OSX/BOStringDemo_OSX-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = "BOStringDemo_OSX/BOStringDemo_OSX-Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				PRODUCT_BUNDLE_IDENTIFIER = "ru.kovpas.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				WRAPPER_EXTENSION = app;
+			};
+			name = Debug;
+		};
+		201DF116185A098100062FB4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7C63CA07892AECA7AA65D714 /* Pods-BOStringDemo_OSX.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "BOStringDemo_OSX/BOStringDemo_OSX-Prefix.pch";
+				INFOPLIST_FILE = "BOStringDemo_OSX/BOStringDemo_OSX-Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				PRODUCT_BUNDLE_IDENTIFIER = "ru.kovpas.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				WRAPPER_EXTENSION = app;
+			};
+			name = Release;
+		};
+		201DF117185A098100062FB4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 764245D088FCC0326DEB9CA4 /* Pods-BOStringTests_OSX.debug.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/BOStringDemo_OSX.app/Contents/MacOS/BOStringDemo_OSX";
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+					"$(inherited)",
+				);
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "BOStringDemo_OSX/BOStringDemo_OSX-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = "BOStringDemo_OSXTests/BOStringDemo_OSXTests-Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				PRODUCT_BUNDLE_IDENTIFIER = "ru.kovpas.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				TEST_HOST = "$(BUNDLE_LOADER)";
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Debug;
+		};
+		201DF118185A098100062FB4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = C1F7A7DD840597E94163C297 /* Pods-BOStringTests_OSX.release.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/BOStringDemo_OSX.app/Contents/MacOS/BOStringDemo_OSX";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+					"$(inherited)",
+				);
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "BOStringDemo_OSX/BOStringDemo_OSX-Prefix.pch";
+				INFOPLIST_FILE = "BOStringDemo_OSXTests/BOStringDemo_OSXTests-Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				PRODUCT_BUNDLE_IDENTIFIER = "ru.kovpas.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				TEST_HOST = "$(BUNDLE_LOADER)";
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Release;
+		};
+		2051B750184799DA00D6DA45 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		2051B751184799DA00D6DA45 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		2051B753184799DA00D6DA45 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = C4D3589F8C646E0F714807CC /* Pods-BOStringDemo_iOS.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "BOStringDemo/BOStringDemo-Prefix.pch";
+				INFOPLIST_FILE = "BOStringDemo/BOStringDemo-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "ru.kovpas.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = app;
+			};
+			name = Debug;
+		};
+		2051B754184799DA00D6DA45 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = BCBDA0AF5EC6CCD70B601D36 /* Pods-BOStringDemo_iOS.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "BOStringDemo/BOStringDemo-Prefix.pch";
+				INFOPLIST_FILE = "BOStringDemo/BOStringDemo-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "ru.kovpas.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = app;
+			};
+			name = Release;
+		};
+		20F46304185607A300A92906 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 364B2B2C5DC159EBF2E68F31 /* Pods-BOStringTests_iOS.debug.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/BOStringDemo_iOS.app/BOStringDemo_iOS";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "BOStringTests/BOStringTests-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = "BOStringTests/BOStringTests-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "ru.kovpas.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUNDLE_LOADER)";
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Debug;
+		};
+		20F46305185607A300A92906 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6DA05E2799A21BBC0644D01D /* Pods-BOStringTests_iOS.release.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/BOStringDemo_iOS.app/BOStringDemo_iOS";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "BOStringTests/BOStringTests-Prefix.pch";
+				INFOPLIST_FILE = "BOStringTests/BOStringTests-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "ru.kovpas.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUNDLE_LOADER)";
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		201DF119185A098100062FB4 /* Build configuration list for PBXNativeTarget "BOStringDemo_OSX" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				201DF115185A098100062FB4 /* Debug */,
+				201DF116185A098100062FB4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		201DF11A185A098100062FB4 /* Build configuration list for PBXNativeTarget "BOStringTests_OSX" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				201DF117185A098100062FB4 /* Debug */,
+				201DF118185A098100062FB4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2051B721184799DA00D6DA45 /* Build configuration list for PBXProject "BOStringDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2051B750184799DA00D6DA45 /* Debug */,
+				2051B751184799DA00D6DA45 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2051B752184799DA00D6DA45 /* Build configuration list for PBXNativeTarget "BOStringDemo_iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2051B753184799DA00D6DA45 /* Debug */,
+				2051B754184799DA00D6DA45 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		20F46303185607A300A92906 /* Build configuration list for PBXNativeTarget "BOStringTests_iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				20F46304185607A300A92906 /* Debug */,
+				20F46305185607A300A92906 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 2051B71E184799DA00D6DA45 /* Project object */;
+}

--- a/Podfile
+++ b/Podfile
@@ -1,25 +1,33 @@
 workspace 'BOString'
 
-xcodeproj 'Examples/BOStringDemo'
+project 'Examples/BOStringDemo'
 
-target 'BOStringDemo_OSX', :exclusive => false do
+target 'BOStringDemo_OSX' do
   platform :osx, '10.9'
   pod 'BOString', :path => './'
+
+  target 'BOStringTests_OSX' do
+    inherit! :search_paths
+    platform :osx, '10.9'
+  
+    pod 'Specta'
+    pod 'Expecta'
+  end
 end
 
-target 'BOStringDemo_iOS', :exclusive => false do
+target 'BOStringDemo_iOS' do
   platform :ios, '6.0'
   pod 'BOString', :path => './'
+
+  target 'BOStringTests_iOS' do
+    inherit! :search_paths
+
+    pod 'Specta'
+    pod 'Expecta'
+  end
 end
 
-target 'BOStringTests_OSX', :exclusive => true do
-  platform :osx, '10.9'
-  pod 'Specta'
-  pod 'Expecta'
-end
 
-target 'BOStringTests_iOS', :exclusive => true do
-  pod 'Specta'
-  pod 'Expecta'
-end
+
+
 

--- a/Tests/BOStringTests.m
+++ b/Tests/BOStringTests.m
@@ -582,6 +582,19 @@ describe(@"Substring should highlight", ^{
 
         expect(result).to.equal(testAttributedString);
     });
+    
+    it(@"all instances, also when containing regexp meta characters", ^{
+        NSString *testString = @"Dollar sign, or $, is a meta character";
+        NSAttributedString *result = [testString makeString:^(BOStringMaker *make) {
+            make.each.substring(@"$", ^{
+                make.foregroundColor([BOSColor greenColor]);
+            });
+        }];
+        
+        NSMutableAttributedString *testAttributedString = [[NSMutableAttributedString alloc] initWithString:testString];
+        [testAttributedString addAttribute:NSForegroundColorAttributeName value:[BOSColor greenColor] range:NSMakeRange(16, 1)];
+        expect(result).to.equal(testAttributedString);
+    });
 
     it(@"first regexp match", ^{
         NSAttributedString *result = [testString makeString:^(BOStringMaker *make) {


### PR DESCRIPTION
Thanks for an excellent library!

I discovered an issue with regex meta characters in substrings. Currently it is not possible to apply attributes to all occurrences of a substring containing for example a dollar sign. It is for example not possible to attribute the price in a sentence such as "The price of the item is $200" with the `each.substrings` syntax. I think that meta characters should always be ignored in substrings. 

Also fixed Travis issues by updating the Podfile to the new format: http://blog.cocoapods.org/CocoaPods-1.0-Migration-Guide/.

I have requested to merge into `master` as `develop` is behind. Feel free to forward `develop` and  close this request. I will then submit a new pull request.
